### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ const unsubscribe = events.subscribe(value => {
   console.log('got value:', value)
 })
 
-pubsub.publish('Hello')
+events.publish('Hello')
 // => 'got value: Hello'
 
-pubsub.publish('World')
+events.publish('World')
 // => 'got value: World'
 
 unsubscribe()
 
-pubsub.publish('Something')
+events.publish('Something')
 
 // ...nothing
 ```


### PR DESCRIPTION
I believe the example in the readme is incorrect? There is no `pubsub` variable to publish to...